### PR TITLE
fix bundle for native

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dist"
   ],
   "scripts": {
-    "compile": "microbundle build -f modern,umd",
+    "compile": "microbundle build -f modern,umd --external ./batchedUpdates",
+    "postcompile": "cp src/batchedUpdates*.js dist",
     "test": "run-s eslint tsc-test jest",
     "eslint": "eslint --ext .js,.ts,.tsx --ignore-pattern dist .",
     "jest": "jest",


### PR DESCRIPTION
v1.2.0 added `batchedUpdates.js` and `batchedUpdates.native.js` but only bundle for react-dom. This should fix it.

Reported in https://github.com/pmndrs/jotai/issues/81