### PR TITLE
experimental suspense/transition support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- experimental suspense/transition support #80
 
 ## [1.3.10] - 2022-04-12
 ### Changed

--- a/__tests__/02_tearing_spec.tsx
+++ b/__tests__/02_tearing_spec.tsx
@@ -45,7 +45,7 @@ describe.skip('tearing spec', () => {
       // It tears.
       // The React app is actually failing,
       // but we don't catch it.
-      fireEvent.click(getAllByText('+1')[0]);
+      fireEvent.click(getAllByText('+1')[0] as Element);
     }).not.toThrow();
   });
 });

--- a/examples/03_suspense/src/Provider.tsx
+++ b/examples/03_suspense/src/Provider.tsx
@@ -55,7 +55,7 @@ export const useMyState = () => {
   return {
     state: value.state,
     increment: useCallback(() => {
-      update(value.increment);
+      update(value.increment, { suspense: true });
     }, [update, value.increment]),
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,31 +169,31 @@ export function useContextSelector<Value, Selected>(
   const selected = selector(value);
   const [state, dispatch] = useReducer((
     prev: readonly [Value, Selected],
-    next?: Parameters<Listener<Value>>[0],
+    action?: Parameters<Listener<Value>>[0],
   ) => {
-    if (!next) {
+    if (!action) {
       // case for `dispatch()` below
       return [value, selected] as const;
     }
-    if ('p' in next) {
-      throw next.p;
+    if ('p' in action) {
+      throw action.p;
     }
-    if (next.n === version) {
+    if (action.n === version) {
       if (Object.is(prev[1], selected)) {
         return prev; // bail out
       }
       return [value, selected] as const;
     }
     try {
-      if ('v' in next) {
-        if (Object.is(prev[0], next.v)) {
+      if ('v' in action) {
+        if (Object.is(prev[0], action.v)) {
           return prev; // do not update
         }
-        const nextSelected = selector(next.v);
+        const nextSelected = selector(action.v);
         if (Object.is(prev[1], nextSelected)) {
           return prev; // do not update
         }
-        return [next.v, nextSelected] as const;
+        return [action.v, nextSelected] as const;
       }
     } catch (e) {
       // ignored (stale props or some other reason)

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,16 +74,13 @@ const createProvider = <Value>(
           };
           if (options?.suspense) {
             action.n *= -1; // this is intentional to make it temporary version
-            const promise = new Promise<Value>((r) => {
+            action.p = new Promise<Value>((r) => {
               setResolve(() => (v: Value) => {
                 action.v = v;
+                delete action.p;
                 r(v);
               });
             });
-            promise.then(() => {
-              delete action.p;
-            });
-            action.p = promise;
           }
           listeners.forEach((listener) => listener(action));
           thunk();
@@ -234,7 +231,7 @@ export function useContext<Value>(context: Context<Value>) {
  * This hook returns an update function that accepts a thunk function
  *
  * Use this for a function that will change a value in
- * [Concurrent Mode](https://reactjs.org/docs/concurrent-mode-intro.html).
+ * concurrent rendering in React 18.
  * Otherwise, there's no need to use this hook.
  *
  * @example

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,10 @@ const createProvider = <Value>(
     const valueRef = useRef(value);
     const versionRef = useRef(0);
     const [resolve, setResolve] = useState<((v: Value) => void) | null>(null);
-    resolve?.(value);
+    if (resolve) {
+      resolve(value);
+      setResolve(null);
+    }
     const contextValue = useRef<ContextValue<Value>>();
     if (!contextValue.current) {
       const listeners = new Set<Listener<Value>>();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "allowJs": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "sourceMap": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
To better work with suspense/transition, we need to throw a promise in sync.
This adds a `{ suspense: true }` option for update, and tries best.
This is highly experimental, and hacky. But, it doesn't break the previous behaviors.
