### PR TITLE
fix(react-native): metro without exports support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- fix(react-native): metro without exports support #118
 
 ## [1.4.3] - 2024-03-06
 ### Changed

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "source": "./src/index.ts",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.modern.js",
+  "react-native": "./dist/index.native.modern.mjs",
   "types": "./dist/src/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/src/index.d.ts",
-      "react-native": "./dist/index.native.modern.mjs",
       "import": "./dist/index.modern.mjs",
       "default": "./dist/index.umd.js"
     }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/src/index.d.ts",
+      "react-native": "./dist/index.native.modern.mjs",
       "import": "./dist/index.modern.mjs",
       "default": "./dist/index.umd.js"
     }


### PR DESCRIPTION
close #115 again